### PR TITLE
Fix toarch load to run on CPU as well

### DIFF
--- a/test.py
+++ b/test.py
@@ -56,7 +56,7 @@ parser.add_argument('--no-cuda', action='store_true',
                     help='disable CUDA')
 
 def get_model(path):
-    ckpt = torch.load(path)
+    ckpt = torch.load(path, map_location=torch.device(device))
     train_args = ckpt['args']
     model = {'dae': DAE, 'vae': VAE, 'aae': AAE}[train_args.model_type](
         vocab, train_args).to(device)


### PR DESCRIPTION
Fix toarch load to run on CPU as well

Otherwise error when running on CPU occurs:
Traceback (most recent call last):
  File "/mnt/Program/Projects/Python/text-autoencoders/test.py", line 111, in <module>
    model = get_model(os.path.join(args.checkpoint, 'model.pt'))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Program/Projects/Python/text-autoencoders/test.py", line 59, in get_model
    ckpt = torch.load(path)
           ^^^^^^^^^^^^^^^^
  File "/mnt/Program/Projects/Python/text-autoencoders/.venv/lib/python3.11/site-packages/torch/serialization.py", line 1026, in load
    return _load(opened_zipfile,
           ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Program/Projects/Python/text-autoencoders/.venv/lib/python3.11/site-packages/torch/serialization.py", line 1438, in _load
    result = unpickler.load()
             ^^^^^^^^^^^^^^^^
  File "/mnt/Program/Projects/Python/text-autoencoders/.venv/lib/python3.11/site-packages/torch/serialization.py", line 1408, in persistent_load
    typed_storage = load_tensor(dtype, nbytes, key, _maybe_decode_ascii(location))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Program/Projects/Python/text-autoencoders/.venv/lib/python3.11/site-packages/torch/serialization.py", line 1382, in load_tensor
    wrap_storage=restore_location(storage, location),
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Program/Projects/Python/text-autoencoders/.venv/lib/python3.11/site-packages/torch/serialization.py", line 391, in default_restore_location
    result = fn(storage, location)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Program/Projects/Python/text-autoencoders/.venv/lib/python3.11/site-packages/torch/serialization.py", line 266, in _cuda_deserialize
    device = validate_cuda_device(location)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Program/Projects/Python/text-autoencoders/.venv/lib/python3.11/site-packages/torch/serialization.py", line 250, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.